### PR TITLE
Deploy github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: deploy to lambda
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy_source:
+    name: deploy to aws lambda
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@
+
+      - name: zip
+        uses: montudor/action-zip@v0.1.0
+        with:
+          args: zip -r viernes.zip viernes/*.py
+  
+      - name: default deploy
+        uses: appleboy/lambda-action@master
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: us-east-1
+          function_name: por-suerte-es-viernes
+          zip_file: viernes.zip


### PR DESCRIPTION
# Proposed changes
- Use github actions to deploy new versions of the bot when merging or pushing to the main branch.
- Closes #3 